### PR TITLE
Monitor target handle rewrite

### DIFF
--- a/CullFactory/Behaviours/DynamicCuller.cs
+++ b/CullFactory/Behaviours/DynamicCuller.cs
@@ -77,10 +77,10 @@ public sealed class DynamicCuller : MonoBehaviour
         foreach (var monitor in _enabledMonitors)
         {
             var targetTransform = monitor.radarTargets[monitor.targetTransformIndex].transform;
-            if (!EntranceTeleportExtender.IsInsideFactory(targetTransform))
-                continue;
-
-            CullOrigins.Add(targetTransform.position);
+            /*if (!EntranceTeleportExtender.IsInsideFactory(targetTransform))
+                continue;*/
+            if (RadarMapExtender.NeedsCulling(monitor.targetTransformIndex)) 
+            { CullOrigins.Add(targetTransform.position); }
         }
 
         if (FocusedPlayer.isInsideFactory || CullOrigins.Count > 0)

--- a/CullFactory/Behaviours/DynamicCuller.cs
+++ b/CullFactory/Behaviours/DynamicCuller.cs
@@ -78,8 +78,10 @@ public sealed class DynamicCuller : MonoBehaviour
         {
             var targetTransform = monitor.radarTargets[monitor.targetTransformIndex].transform;
             /*if (!EntranceTeleportExtender.IsInsideFactory(targetTransform))
-                continue;*/
-            if (RadarMapExtender.NeedsCulling(monitor.targetTransformIndex)) 
+                continue;*/ //Old method
+            
+            //This handles both non local Players and Radars being in facility
+            if (RadarTargetExtender.NeedsCulling(monitor.targetTransformIndex)) 
             { CullOrigins.Add(targetTransform.position); }
         }
 

--- a/CullFactory/Extenders/RadarMapExtender.cs
+++ b/CullFactory/Extenders/RadarMapExtender.cs
@@ -1,7 +1,5 @@
-﻿using System;
+﻿using System.Collections;
 using System.Collections.Generic;
-using System.Diagnostics;
-using CullFactory.Behaviours;
 using GameNetcodeStuff;
 using HarmonyLib;
 using UnityEngine;
@@ -9,7 +7,7 @@ using static CullFactory.Plugin;
 
 namespace CullFactory.Extenders;
 
-public class RadarMapExtender
+public class RadarMapExtender : MonoBehaviour
 {
     public static int cachedradartarget { get; private set; }
     public static bool cachedneedsculling { get; private set; }
@@ -23,6 +21,7 @@ public class RadarMapExtender
             if (!Target.isNonPlayer)
             {
                 PlayerControllerB Player = Target.transform.gameObject.GetComponentInChildren<PlayerControllerB>();
+                Log($"IsInside {Player.isInsideFactory}");
                 if (Player.playerClientId != GameNetworkManager.Instance.localPlayerController.playerClientId &&
                     Player.isInsideFactory)
                 {
@@ -45,8 +44,18 @@ public class RadarMapExtender
         cachedneedsculling = false;
         return false;
     }
+
     [HarmonyPatch(typeof(PlayerControllerB), "TeleportPlayer")]
     [HarmonyPostfix]
-    public static void OnTeleport()
-    { NeedsCulling(cachedradartarget, true); }
+    public static void OnTeleport(PlayerControllerB __instance)
+    {
+        NeedsCulling(cachedradartarget, true);
+       // __instance.StartCoroutine(checkculling());
+    }
+    
+   /*public static IEnumerator checkculling()
+    {
+        yield return new WaitForSeconds(0.5f); //Waiting before checking
+        NeedsCulling(cachedradartarget, true); //Forcing function to recheck current target
+    }*/
 }

--- a/CullFactory/Extenders/RadarMapExtender.cs
+++ b/CullFactory/Extenders/RadarMapExtender.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using CullFactory.Behaviours;
+using HarmonyLib;
+using UnityEngine;
+using static CullFactory.Plugin;
+namespace CullFactory.Extenders;
+public class RadarMapExtender
+{
+    [HarmonyPatch(typeof(ManualCameraRenderer), "updateMapTarget")]
+    [HarmonyPostfix]
+    private static void OnTargetSwitch(ref int setRadarTargetIndex, ManualCameraRenderer __instance)
+    {
+       // __instance.radarTargets[1].isNonPlayer
+       if (!__instance.radarTargets[__instance.targetTransformIndex].isNonPlayer)
+       {
+           Log(__instance.radarTargets[__instance.targetTransformIndex].transform.gameObject.ToString());
+       }
+       else
+       {
+           Log(__instance.radarTargets[__instance.targetTransformIndex].transform.gameObject.ToString());
+       }
+    }
+    [HarmonyPatch(typeof(ManualCameraRenderer), "Update")]
+    [HarmonyPostfix]
+    private static void OnUpdate(ManualCameraRenderer __instance)
+    {
+        // __instance.radarTargets[1].isNonPlayer
+        //this.radarTargets[this.targetTransformIndex].transform
+        //Log(__instance.radarTargets[__instance.targetTransformIndex].transform.ToString());
+    }
+}

--- a/CullFactory/Extenders/RadarTargetExtender.cs
+++ b/CullFactory/Extenders/RadarTargetExtender.cs
@@ -7,34 +7,39 @@ using static CullFactory.Plugin;
 
 namespace CullFactory.Extenders;
 
-public class RadarMapExtender : MonoBehaviour
+public class RadarTargetExtender : MonoBehaviour
 {
     public static int cachedradartarget { get; private set; }
     public static bool cachedneedsculling { get; private set; }
+    //Gets called every DynamicCuller.Update() tick
     public static bool NeedsCulling(int TargetIndex, bool force = false)
     {
-        if (TargetIndex == cachedradartarget && !force) { return cachedneedsculling; }
+        //Current radar target gets cached and updated only if target changed or forced update on PlayerTeleport event
+        if (TargetIndex == cachedradartarget && !force) { return cachedneedsculling; } 
+        //Expensive calculations ahead
         cachedradartarget = TargetIndex;
         TransformAndName Target = StartOfRound.Instance.mapScreen.radarTargets[TargetIndex];
-        if (Target.transform != null) 
+        if (Target.transform != null) //Safety measures
         {
-            if (!Target.isNonPlayer)
+            if (!Target.isNonPlayer) //If target is Player
             {
                 PlayerControllerB Player = Target.transform.gameObject.GetComponentInChildren<PlayerControllerB>();
                 Log($"IsInside {Player.isInsideFactory}");
                 if (Player.playerClientId != GameNetworkManager.Instance.localPlayerController.playerClientId &&
-                    Player.isInsideFactory)
+                    Player.isInsideFactory) //Check if player is not localplayer and if player inside the factory
                 {
+                    //Result gets cached, target being culled
                     Log($"Added Player {Target.name} as depth culling target");
                     cachedneedsculling = true;
                     return true;
                 }
             }
-            else
+            else //If target is Radar
             {
                 RadarBoosterItem Radar = Target.transform.gameObject.GetComponentInChildren<RadarBoosterItem>();
-                if (Radar.isInFactory)
+                if (Radar.isInFactory) //If Radar is in factory (Doesn't work with EnhancedRadarBooster mod sadly ;-;)
                 {
+                    //Result gets cached, target being culled
                     Log($"Added Booster {Target.name} as depth culling target");
                     cachedneedsculling = true;
                     return true;
@@ -48,14 +53,5 @@ public class RadarMapExtender : MonoBehaviour
     [HarmonyPatch(typeof(PlayerControllerB), "TeleportPlayer")]
     [HarmonyPostfix]
     public static void OnTeleport(PlayerControllerB __instance)
-    {
-        NeedsCulling(cachedradartarget, true);
-       // __instance.StartCoroutine(checkculling());
-    }
-    
-   /*public static IEnumerator checkculling()
-    {
-        yield return new WaitForSeconds(0.5f); //Waiting before checking
-        NeedsCulling(cachedradartarget, true); //Forcing function to recheck current target
-    }*/
+    { NeedsCulling(cachedradartarget, true); } //Force update culling on target if someone teleports in/out of building
 }

--- a/CullFactory/Extenders/RadarTargetExtender.cs
+++ b/CullFactory/Extenders/RadarTargetExtender.cs
@@ -19,9 +19,10 @@ public class RadarTargetExtender : MonoBehaviour
         //Expensive calculations ahead
         cachedradartarget = TargetIndex;
         TransformAndName Target = StartOfRound.Instance.mapScreen.radarTargets[TargetIndex];
-        if (Target.transform != null) //Safety measures
-        {
-            if (!Target.isNonPlayer) //If target is Player
+        //Safety measures
+        if (Target.transform != null)
+        {   //If target is Player
+            if (!Target.isNonPlayer) 
             {
                 PlayerControllerB Player = Target.transform.gameObject.GetComponentInChildren<PlayerControllerB>();
                 Log($"IsInside {Player.isInsideFactory}");
@@ -34,10 +35,12 @@ public class RadarTargetExtender : MonoBehaviour
                     return true;
                 }
             }
-            else //If target is Radar
+            //If target is Radar
+            else 
             {
                 RadarBoosterItem Radar = Target.transform.gameObject.GetComponentInChildren<RadarBoosterItem>();
-                if (Radar.isInFactory) //If Radar is in factory (Doesn't work with EnhancedRadarBooster mod sadly ;-;)
+                //If Radar is in factory (Doesn't work with EnhancedRadarBooster mod sadly ;-;)
+                if (Radar.isInFactory) 
                 {
                     //Result gets cached, target being culled
                     Log($"Added Booster {Target.name} as depth culling target");
@@ -46,6 +49,7 @@ public class RadarTargetExtender : MonoBehaviour
                 }
             }
         }
+        //Target doesn't need to be culled, results are cached
         cachedneedsculling = false;
         return false;
     }
@@ -53,5 +57,15 @@ public class RadarTargetExtender : MonoBehaviour
     [HarmonyPatch(typeof(PlayerControllerB), "TeleportPlayer")]
     [HarmonyPostfix]
     public static void OnTeleport(PlayerControllerB __instance)
-    { NeedsCulling(cachedradartarget, true); } //Force update culling on target if someone teleports in/out of building
+    {
+        //Force update culling on target if someone teleports in/out of building
+        __instance.StartCoroutine(WaitBeforeCheck()); 
+    }
+
+    public static IEnumerator WaitBeforeCheck()
+    {
+        //Waiting 250ms after player teleport event for InFacility property to update
+        yield return new WaitForSeconds(0.25f); 
+        NeedsCulling(cachedradartarget, true); 
+    }
 }

--- a/CullFactory/Plugin.cs
+++ b/CullFactory/Plugin.cs
@@ -24,6 +24,7 @@ namespace CullFactory
             var harmony = new Harmony(Guid);
             harmony.PatchAll(typeof(LevelGenerationExtender));
             harmony.PatchAll(typeof(EntranceTeleportExtender));
+            harmony.PatchAll(typeof(RadarMapExtender));
 
             QualitySettings.shadowResolution = ShadowResolution.Low;
 

--- a/CullFactory/Plugin.cs
+++ b/CullFactory/Plugin.cs
@@ -24,7 +24,7 @@ namespace CullFactory
             var harmony = new Harmony(Guid);
             harmony.PatchAll(typeof(LevelGenerationExtender));
             harmony.PatchAll(typeof(EntranceTeleportExtender));
-            harmony.PatchAll(typeof(RadarMapExtender));
+            harmony.PatchAll(typeof(RadarTargetExtender));
 
             QualitySettings.shadowResolution = ShadowResolution.Low;
 


### PR DESCRIPTION
Added RadarTargetExtender class, which (Hopefully efficiently) handles if current monitor target needs culling for both Players and Radar boosters.